### PR TITLE
spinMyR gains new arguments keepRmd and keepMd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rsalad
 Title: A mix of useful R functions that are good for you
-Version: 0.0.2.1
+Version: 0.0.2.2
 Authors@R: "Dean Attali <daattali@gmail.com> [aut, cre]"
 Description: Collection of functions that help with easily manipulating
     data.frames (e.g. converting variables to factors, rearranging variables)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+- `spinMyR()` gains new arguments `keepRmd` (default: `FALSE`) and `keepMd` (default: `TRUE`) (#15)
+
 # rsalad 0.0.2.1
 
 2015-04-06

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rsalad 0.0.2.2
+
+2015-10-23
+
 - `spinMyR()` gains new arguments `keepRmd` (default: `FALSE`) and `keepMd` (default: `TRUE`) (#15)
 
 # rsalad 0.0.2.1

--- a/R/spinMyR.R
+++ b/R/spinMyR.R
@@ -49,7 +49,7 @@
 #'   kept (\code{TRUE}) or deleted (\code{FALSE})?
 #' @return The path to the output (invisibly).
 #' @section Possible future improvements:
-#' - Add support to only produce one of [Rmd, md, HTML]
+#' - Add support to avoid producing the HTML file
 #' @section Detailed Arguments:
 #' All paths given in the arguments can be either absolute or relative.
 #'

--- a/R/spinMyR.R
+++ b/R/spinMyR.R
@@ -45,6 +45,8 @@
 #' \code{DATASET_NAME}, then you can use
 #' \code{params = list('DATASET_NAME' = 'oct10dat')}
 #' @param warn If TRUE, then show warnings (recommended to keep this on)
+#' @param keepRmd,keepMd Should intermediate \code{Rmd} or \code{md} files be
+#'   kept (\code{TRUE}) or deleted (\code{FALSE})?
 #' @return The path to the output (invisibly).
 #' @section Possible future improvements:
 #' - Add support to only produce one of [Rmd, md, HTML]
@@ -84,7 +86,7 @@ spinMyR <- function(file, wd, outDir, figDir, outSuffix,
                     params = list(),
                     verbose = FALSE,
                     chunkOpts = list(tidy = FALSE, error = FALSE),
-                    warn = TRUE) {
+                    warn = TRUE, keepRmd = FALSE, keepMd = TRUE) {
   rsaladRequire(c("knitr", "markdown"))
 
   if (warn) {
@@ -213,8 +215,14 @@ spinMyR <- function(file, wd, outDir, figDir, outSuffix,
               fileMd,
               quiet = !verbose,
               envir = spinMyR_Env)
+  if (!keepRmd) {
+    unlink(fileRmd)
+  }
   markdown::markdownToHTML(fileMd,
                            fileHtml)
+  if (!keepMd) {
+    unlink(fileMd)
+  }
 
   message(paste0("spinMyR output in\n", outDir))
 

--- a/man/spinMyR.Rd
+++ b/man/spinMyR.Rd
@@ -6,7 +6,7 @@
 \usage{
 spinMyR(file, wd, outDir, figDir, outSuffix, params = list(),
   verbose = FALSE, chunkOpts = list(tidy = FALSE, error = FALSE),
-  warn = TRUE)
+  warn = TRUE, keepRmd = FALSE, keepMd = TRUE)
 }
 \arguments{
 \item{file}{The path to the R script (if \code{wd} is provided, then this
@@ -37,6 +37,9 @@ For example, if the script to execute assumes that there is a variable named
 for a list of chunk options.}
 
 \item{warn}{If TRUE, then show warnings (recommended to keep this on)}
+
+\item{keepRmd,keepMd}{Should intermediate \code{Rmd} or \code{md} files be
+kept (\code{TRUE}) or deleted (\code{FALSE})?}
 }
 \value{
 The path to the output (invisibly).

--- a/man/spinMyR.Rd
+++ b/man/spinMyR.Rd
@@ -74,7 +74,7 @@ directly and using \code{spin} on it.
 }
 \section{Possible future improvements}{
 
-- Add support to only produce one of [Rmd, md, HTML]
+- Add support to avoid producing the HTML file
 }
 
 \section{Detailed Arguments}{


### PR DESCRIPTION
keepRmd = FALSE and keepMd = TRUE by default; I think one rarely needs the intermediate Rmd

Side note: I like the idea of pulling this function (and perhaps spinMyRmd) into a separate package.
